### PR TITLE
feat(golang-rewrite): implement `asdf env` command

### DIFF
--- a/docs/guide/upgrading-from-v0-14-to-v0-15.md
+++ b/docs/guide/upgrading-from-v0-14-to-v0-15.md
@@ -20,6 +20,7 @@ versions are supported. The affected commands:
 * `asdf plugin-list-all` -> `asdf plugin list all`
 * `asdf plugin-update` -> `asdf plugin update`
 * `asdf plugin-remove` -> `asdf plugin remove`
+* `asdf shim-versions` -> `asdf shimversions`
 
 ### `asdf global` and `asdf local` commands have been replaced by the `asdf set` command
 

--- a/internal/execenv/execenv.go
+++ b/internal/execenv/execenv.go
@@ -1,0 +1,49 @@
+// Package execenv contains logic for generating execution environing using a plugin's
+// exec-env callback script if available.
+package execenv
+
+import (
+	"fmt"
+	"strings"
+
+	"asdf/internal/execute"
+	"asdf/internal/plugins"
+)
+
+const execEnvCallbackName = "exec-env"
+
+// Generate runs exec-env callback if available and captures the environment
+// variables it sets. It then parses them and returns them as a map.
+func Generate(plugin plugins.Plugin, callbackEnv map[string]string) (env map[string]string, err error) {
+	execEnvPath, err := plugin.CallbackPath(execEnvCallbackName)
+	if err != nil {
+		return callbackEnv, err
+	}
+
+	var stdout strings.Builder
+
+	// This is done to support the legacy behavior. exec-env is the only asdf
+	// callback that works by exporting environment variables. Because of this,
+	// executing the callback isn't enough. We actually need to source it (.) so
+	// the environment variables get set, and then run `env` so they get printed
+	// to STDOUT.
+	expression := execute.NewExpression(fmt.Sprintf(". \"%s\"; env", execEnvPath), []string{})
+	expression.Env = callbackEnv
+	expression.Stdout = &stdout
+	err = expression.Run()
+
+	return envMap(stdout.String()), err
+}
+
+func envMap(env string) map[string]string {
+	slice := map[string]string{}
+
+	for _, envVar := range strings.Split(env, "\n") {
+		varValue := strings.Split(envVar, "=")
+		if len(varValue) == 2 {
+			slice[varValue[0]] = varValue[1]
+		}
+	}
+
+	return slice
+}

--- a/internal/execenv/execenv_test.go
+++ b/internal/execenv/execenv_test.go
@@ -1,0 +1,43 @@
+package execenv
+
+import (
+	"testing"
+
+	"asdf/internal/config"
+	"asdf/internal/plugins"
+	"asdf/repotest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testPluginName  = "lua"
+	testPluginName2 = "ruby"
+)
+
+func TestGenerate(t *testing.T) {
+	testDataDir := t.TempDir()
+
+	t.Run("returns map of environment variables", func(t *testing.T) {
+		conf := config.Config{DataDir: testDataDir}
+		_, err := repotest.InstallPlugin("dummy_plugin", testDataDir, testPluginName)
+		assert.Nil(t, err)
+		plugin := plugins.New(conf, testPluginName)
+		assert.Nil(t, repotest.WritePluginCallback(plugin.Dir, "exec-env", "#!/usr/bin/env bash\nexport BAZ=bar"))
+		env, err := Generate(plugin, map[string]string{"ASDF_INSTALL_VERSION": "test"})
+		assert.Nil(t, err)
+		assert.Equal(t, "bar", env["BAZ"])
+		assert.Equal(t, "test", env["ASDF_INSTALL_VERSION"])
+	})
+
+	t.Run("returns error when plugin lacks exec-env callback", func(t *testing.T) {
+		conf := config.Config{DataDir: testDataDir}
+		_, err := repotest.InstallPlugin("dummy_plugin", testDataDir, testPluginName2)
+		assert.Nil(t, err)
+		plugin := plugins.New(conf, testPluginName2)
+		env, err := Generate(plugin, map[string]string{})
+		assert.Equal(t, err.(plugins.NoCallbackError).Error(), "Plugin named ruby does not have a callback named exec-env")
+		_, found := env["FOO"]
+		assert.False(t, found)
+	})
+}

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -47,7 +47,7 @@ func (c Command) Run() error {
 
 	cmd := exec.Command("bash", "-c", command)
 
-	cmd.Env = mapToSlice(c.Env)
+	cmd.Env = MapToSlice(c.Env)
 	cmd.Stdin = c.Stdin
 
 	// Capture stdout and stderr
@@ -57,18 +57,33 @@ func (c Command) Run() error {
 	return cmd.Run()
 }
 
+// MapToSlice converts an env map to env slice suitable for syscall.Exec
+func MapToSlice(env map[string]string) (slice []string) {
+	for key, value := range env {
+		slice = append(slice, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return slice
+}
+
+// SliceToMap converts an env map to env slice suitable for syscall.Exec
+func SliceToMap(env []string) map[string]string {
+	envMap := map[string]string{}
+
+	for _, envVar := range env {
+		varValue := strings.Split(envVar, "=")
+		if len(varValue) == 2 {
+			envMap[varValue[0]] = varValue[1]
+		}
+	}
+
+	return envMap
+}
+
 func formatArgString(args []string) string {
 	var newArgs []string
 	for _, str := range args {
 		newArgs = append(newArgs, fmt.Sprintf("\"%s\"", str))
 	}
 	return strings.Join(newArgs, " ")
-}
-
-func mapToSlice(env map[string]string) (slice []string) {
-	for key, value := range env {
-		slice = append(slice, fmt.Sprintf("%s=%s", key, value))
-	}
-
-	return slice
 }

--- a/main_test.go
+++ b/main_test.go
@@ -75,9 +75,9 @@ func TestBatsTests(t *testing.T) {
 		runBatsFile(t, dir, "reshim_command.bats")
 	})
 
-	//t.Run("shim_env_command", func(t *testing.T) {
-	//  runBatsFile(t, dir, "shim_env_command.bats")
-	//})
+	t.Run("shim_env_command", func(t *testing.T) {
+		runBatsFile(t, dir, "shim_env_command.bats")
+	})
 
 	//t.Run("shim_exec", func(t *testing.T) {
 	//  runBatsFile(t, dir, "shim_exec.bats")


### PR DESCRIPTION
* Create `CallbackPath` method on `Plugin` struct
* Correct behavior of `asdf shimversions` command
* Update `shims.FindExecutable` function to return plugin
* Create `repotest.WritePluginCallback` function
* Create `execenv` package for invoking `exec-env` plugin callback
* Make `MapToSlice` a public function
* Return resolved version from `shims.FindExecutable` function
* Create `shims.ExecutablePaths` function
* Enable `shim_env_command.bats` tests
* Implement `asdf env` command