### PR TITLE
fix(golang-rewrite): `asdf exec` and `asdf env` command fixes

### DIFF
--- a/internal/execenv/execenv.go
+++ b/internal/execenv/execenv.go
@@ -4,6 +4,7 @@ package execenv
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"asdf/internal/execute"
@@ -11,6 +12,20 @@ import (
 )
 
 const execEnvCallbackName = "exec-env"
+
+// CurrentEnv returns the current environment as a map
+func CurrentEnv() map[string]string {
+	return SliceToMap(os.Environ())
+}
+
+// MergeEnv takes two maps with string keys and values and merges them.
+func MergeEnv(map1, map2 map[string]string) map[string]string {
+	for key, value := range map2 {
+		map1[key] = value
+	}
+
+	return map1
+}
 
 // Generate runs exec-env callback if available and captures the environment
 // variables it sets. It then parses them and returns them as a map.
@@ -46,4 +61,18 @@ func envMap(env string) map[string]string {
 	}
 
 	return slice
+}
+
+// SliceToMap converts an env map to env slice suitable for syscall.Exec
+func SliceToMap(env []string) map[string]string {
+	envMap := map[string]string{}
+
+	for _, envVar := range env {
+		varValue := strings.Split(envVar, "=")
+		if len(varValue) == 2 {
+			envMap[varValue[0]] = varValue[1]
+		}
+	}
+
+	return envMap
 }

--- a/internal/execenv/execenv_test.go
+++ b/internal/execenv/execenv_test.go
@@ -15,6 +15,39 @@ const (
 	testPluginName2 = "ruby"
 )
 
+func TestCurrentEnv(t *testing.T) {
+	t.Run("returns map of current environment", func(t *testing.T) {
+		envMap := CurrentEnv()
+		path, found := envMap["PATH"]
+		assert.True(t, found)
+		assert.NotEmpty(t, path)
+	})
+}
+
+func TestMergeEnv(t *testing.T) {
+	t.Run("merges two maps", func(t *testing.T) {
+		map1 := map[string]string{"Key": "value"}
+		map2 := map[string]string{"Key2": "value2"}
+		map3 := MergeEnv(map1, map2)
+		assert.Equal(t, map3["Key"], "value")
+		assert.Equal(t, map3["Key2"], "value2")
+	})
+
+	t.Run("doesn't change original map", func(t *testing.T) {
+		map1 := map[string]string{"Key": "value"}
+		map2 := map[string]string{"Key2": "value2"}
+		_ = MergeEnv(map1, map2)
+		assert.Equal(t, map1["Key2"], "value2")
+	})
+
+	t.Run("second map overwrites values in first", func(t *testing.T) {
+		map1 := map[string]string{"Key": "value"}
+		map2 := map[string]string{"Key": "value2"}
+		map3 := MergeEnv(map1, map2)
+		assert.Equal(t, map3["Key"], "value2")
+	})
+}
+
 func TestGenerate(t *testing.T) {
 	testDataDir := t.TempDir()
 

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -66,20 +66,6 @@ func MapToSlice(env map[string]string) (slice []string) {
 	return slice
 }
 
-// SliceToMap converts an env map to env slice suitable for syscall.Exec
-func SliceToMap(env []string) map[string]string {
-	envMap := map[string]string{}
-
-	for _, envVar := range env {
-		varValue := strings.Split(envVar, "=")
-		if len(varValue) == 2 {
-			envMap[varValue[0]] = varValue[1]
-		}
-	}
-
-	return envMap
-}
-
 func formatArgString(args []string) string {
 	var newArgs []string
 	for _, str := range args {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -12,6 +12,11 @@ func TestRemoveFromPath(t *testing.T) {
 		assert.Equal(t, got, "/foo/bar:/home/user/bin")
 	})
 
+	t.Run("returns PATH string with multiple matching paths removed", func(t *testing.T) {
+		got := RemoveFromPath("/foo/bar:/baz/bim:/baz/bim:/home/user/bin", "/baz/bim")
+		assert.Equal(t, got, "/foo/bar:/home/user/bin")
+	})
+
 	t.Run("returns PATH string unchanged when no matching path found", func(t *testing.T) {
 		got := RemoveFromPath("/foo/bar:/baz/bim:/home/user/bin", "/path-not-present/")
 		assert.Equal(t, got, "/foo/bar:/baz/bim:/home/user/bin")


### PR DESCRIPTION
* Create `CurrentEnv` and `MergeEnv` helper functions
* Add another test for `paths.RemoveFromPath` function
* Move executable finding functions to shims package
* Correct PATH code for env and exec commands