### PR TITLE
feat(golang-rewrite): implement asdf plugin extension commands

### DIFF
--- a/docs/guide/upgrading-from-v0-14-to-v0-15.md
+++ b/docs/guide/upgrading-from-v0-14-to-v0-15.md
@@ -49,6 +49,63 @@ not an executable. The new rewrite removes all shell code from asdf, and it is
 now a binary rather than a shell function, so setting environment variables
 directly in the shell is no longer possible.
 
+### Plugin extension commands must now be prefixed with `cmd`
+
+Previously plugin extension commands could be run like this:
+
+```
+asdf nodejs nodebuild --version
+```
+
+Now they must be prefixed with `cmd` to avoid causing confusion with built-in
+commands:
+
+```
+asdf cmd nodejs nodebuild --version
+```
+
+### Extension commands have been redesigned
+
+There are a number of breaking changes for plugin extension commands:
+
+* They must be runnable by `exec` syscall. If your extension commands are shell
+scripts in order to be run with `exec` they must start with a proper shebang
+line.
+* They can now be binaries or scripts in any language. It no
+longer makes sense to require a `.bash` extension as it is misleading.
+* They must have executable permission set.
+* They are no longer sourced by asdf as Bash scripts when they lack executable
+permission.
+
+Additionally, only the first argument after plugin name is used to determine
+the extension command to run. This means effectively there is the default
+`command` extension command that asdf defaults to when no command matching the
+first argument after plugin name is found. For example:
+
+```
+foo/
+  lib/commands/
+    command
+    command-bar
+    command-bat-man
+```
+
+Previously these scripts would work like this:
+
+```
+$ asdf cmd foo         # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command`
+$ asdf cmd foo bar     # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bar`
+$ asdf cmd foo bat man # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bat-man`
+```
+
+Now:
+
+```
+$ asdf cmd foo         # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command`
+$ asdf cmd foo bar     # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bar`
+$ asdf cmd foo bat man # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command bat man`
+```
+
 ### Executables Shims Resolve to Must Runnable by `syscall.Exec`
 
 The most obvious example of this breaking change are scripts that lack a proper

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -56,12 +56,24 @@ func (e NoCallbackError) Error() string {
 	return fmt.Sprintf(hasNoCallbackMsg, e.plugin, e.callback)
 }
 
+// NoCommandError is an error returned by ExtensionCommandPath when an extension
+// command with the given name does not exist
+type NoCommandError struct {
+	command string
+	plugin  string
+}
+
+func (e NoCommandError) Error() string {
+	return fmt.Sprintf(hasNoCommandMsg, e.plugin, e.command)
+}
+
 const (
 	dataDirPlugins         = "plugins"
 	invalidPluginNameMsg   = "%s is invalid. Name may only contain lowercase letters, numbers, '_', and '-'"
 	pluginAlreadyExistsMsg = "Plugin named %s already added"
 	pluginMissingMsg       = "Plugin named %s not installed"
 	hasNoCallbackMsg       = "Plugin named %s does not have a callback named %s"
+	hasNoCommandMsg        = "Plugin named %s does not have a extension command named %s"
 )
 
 // Plugin struct represents an asdf plugin to all asdf code. The name and dir
@@ -174,6 +186,52 @@ func (p Plugin) CallbackPath(name string) (string, error) {
 	_, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", NoCallbackError{callback: name, plugin: p.Name}
+	}
+
+	return path, nil
+}
+
+// GetExtensionCommands returns a slice of strings representing all available
+// extension commands for the plugin.
+func (p Plugin) GetExtensionCommands() ([]string, error) {
+	commands := []string{}
+	files, err := os.ReadDir(filepath.Join(p.Dir, "lib/commands"))
+	if _, ok := err.(*fs.PathError); ok {
+		return commands, nil
+	}
+
+	if err != nil {
+		return commands, err
+	}
+
+	for _, file := range files {
+		if !file.IsDir() {
+			name := file.Name()
+			if name == "command" {
+				commands = append(commands, "")
+			} else {
+				if strings.HasPrefix(name, "command-") {
+					commands = append(commands, strings.TrimPrefix(name, "command-"))
+				}
+			}
+		}
+	}
+	return commands, nil
+}
+
+// ExtensionCommandPath returns the path to the plugin's extension command
+// script matching the name if it exists.
+func (p Plugin) ExtensionCommandPath(name string) (string, error) {
+	commandName := "command"
+
+	if name != "" {
+		commandName = fmt.Sprintf("command-%s", name)
+	}
+
+	path := filepath.Join(p.Dir, "lib", "commands", commandName)
+	_, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", NoCommandError{command: name, plugin: p.Name}
 	}
 
 	return path, nil

--- a/main_test.go
+++ b/main_test.go
@@ -47,9 +47,9 @@ func TestBatsTests(t *testing.T) {
 		runBatsFile(t, dir, "plugin_add_command.bats")
 	})
 
-	//t.Run("plugin_extension_command", func(t *testing.T) {
-	//  runBatsFile(t, dir, "plugin_extension_command.bats")
-	//})
+	t.Run("plugin_extension_command", func(t *testing.T) {
+		runBatsFile(t, dir, "plugin_extension_command.bats")
+	})
 
 	t.Run("plugin_list_all_command", func(t *testing.T) {
 		runBatsFile(t, dir, "plugin_list_all_command.bats")
@@ -91,6 +91,10 @@ func TestBatsTests(t *testing.T) {
 		runBatsFile(t, dir, "uninstall_command.bats")
 	})
 
+	// Version commands like `asdf global` and `asdf local` aren't going to be
+	// available, however it would be nice to still support environment variable
+	// versions, e.g. ASDF_RUBY_VERSION=2.0.0. Some of these tests could be
+	// enabled and implemented.
 	//t.Run("version_commands", func(t *testing.T) {
 	//  runBatsFile(t, dir, "version_commands.bats")
 	//})

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -18,15 +18,15 @@ teardown() {
 @test "asdf help shows plugin extension commands" {
   local plugin_path listed_cmds
   plugin_path="$(get_plugin_path dummy)"
-  touch "$plugin_path/lib/commands/command.bash"
-  touch "$plugin_path/lib/commands/command-foo.bash"
-  touch "$plugin_path/lib/commands/command-foo-bar.bash"
+  touch "$plugin_path/lib/commands/command"
+  touch "$plugin_path/lib/commands/command-foo"
+  touch "$plugin_path/lib/commands/command-foo-bar"
   run asdf help
   [ "$status" -eq 0 ]
   echo "$output" | grep "PLUGIN dummy" # should present plugin section
   listed_cmds=$(echo "$output" | grep -c "asdf dummy")
   [ "$listed_cmds" -eq 3 ]
-  echo "$output" | grep "asdf dummy foo bar" # should present commands without hyphens
+  echo "$output" | grep "asdf dummy foo-bar"
 }
 
 @test "asdf help shows extension commands for plugin with hyphens in the name" {
@@ -37,9 +37,9 @@ teardown() {
 
   plugin_path="$(get_plugin_path $plugin_name)"
   mkdir -p "$plugin_path/lib/commands"
-  touch "$plugin_path/lib/commands/command.bash"
-  touch "$plugin_path/lib/commands/command-foo.bash"
-  touch "$plugin_path/lib/commands/command-foo-bar.bash"
+  touch "$plugin_path/lib/commands/command"
+  touch "$plugin_path/lib/commands/command-foo"
+  touch "$plugin_path/lib/commands/command-foo-bar"
 
   run asdf help
   [ "$status" -eq 0 ]
@@ -47,52 +47,55 @@ teardown() {
   listed_cmds=$(grep -c "asdf $plugin_name" <<<"${output}")
   [[ $listed_cmds -eq 3 ]]
   [[ "$output" == *"asdf $plugin_name foo"* ]]
-  [[ "$output" == *"asdf $plugin_name foo bar"* ]]
+  [[ "$output" == *"asdf $plugin_name foo-bar"* ]]
 }
 
 @test "asdf can execute plugin bin commands" {
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy foo` command
-  cat <<'EOF' >"$plugin_path/lib/commands/command-foo.bash"
+  cat <<'EOF' >"$plugin_path/lib/commands/command-foo"
 #!/usr/bin/env bash
 echo this is an executable $*
 EOF
-  chmod +x "$plugin_path/lib/commands/command-foo.bash"
+  chmod +x "$plugin_path/lib/commands/command-foo"
 
   expected="this is an executable bar"
 
-  run asdf dummy foo bar
+  run asdf cmd dummy foo bar
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
 
-@test "asdf can source plugin bin scripts" {
-  plugin_path="$(get_plugin_path dummy)"
+# No longer supported. If you want to do this you'll need to manual source the
+# file containing the functions you want via relative path.
+#@test "asdf can source plugin bin scripts" {
+#  plugin_path="$(get_plugin_path dummy)"
 
-  # this plugin defines a new `asdf dummy foo` command
-  echo 'echo sourced script has asdf utils $(get_plugin_path dummy) $*' >"$plugin_path/lib/commands/command-foo.bash"
+#  # this plugin defines a new `asdf dummy foo` command
+#  echo '#!/usr/bin/env bash
+#  echo sourced script has asdf utils $(get_plugin_path dummy) $*' >"$plugin_path/lib/commands/command-foo"
 
-  expected="sourced script has asdf utils $plugin_path bar"
+#  expected="sourced script has asdf utils $plugin_path bar"
 
-  run asdf dummy foo bar
-  [ "$status" -eq 0 ]
-  [ "$output" = "$expected" ]
-}
+#  run asdf cmd dummy foo bar
+#  [ "$status" -eq 0 ]
+#  [ "$output" = "$expected" ]
+#}
 
 @test "asdf can execute plugin default command without arguments" {
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy` command
-  cat <<'EOF' >"$plugin_path/lib/commands/command.bash"
+  cat <<'EOF' >"$plugin_path/lib/commands/command"
 #!/usr/bin/env bash
 echo hello
 EOF
-  chmod +x "$plugin_path/lib/commands/command.bash"
+  chmod +x "$plugin_path/lib/commands/command"
 
   expected="hello"
 
-  run asdf dummy
+  run asdf cmd dummy
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
@@ -101,15 +104,15 @@ EOF
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy` command
-  cat <<'EOF' >"$plugin_path/lib/commands/command.bash"
+  cat <<'EOF' >"$plugin_path/lib/commands/command"
 #!/usr/bin/env bash
 echo hello $*
 EOF
-  chmod +x "$plugin_path/lib/commands/command.bash"
+  chmod +x "$plugin_path/lib/commands/command"
 
   expected="hello world"
 
-  run asdf dummy world
+  run asdf cmd dummy world
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }


### PR DESCRIPTION
* Enable `plugin_extension_command.bats` tests
* Add comment on `version_commands.bats` tests
* Show help output when asdf run with no arguments
* Document breaking change in asdf extension commands feature
* Create `Plugin.ExtensionCommandPath` method
* Create `asdf cmd` subcommand
* Get `plugin_extension_command.bats` tests passing
* Document breaking changes to asdf extension commands
