### PR TITLE
feat(golang-rewrite): rename module and move `main` pacakge to `cmd/asdf`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           go-version: '1.21.5'
       - name: Install dependencies
-        run: go get .
+        run: go get ./...
       - name: Install gofumpt for formatting
         run: go install mvdan.cc/gofumpt@latest
       - name: Run 'gofumpt'
@@ -42,7 +42,7 @@ jobs:
       - name: Run 'revive'
         run: revive -set_exit_status ./...
       - name: Vet
-        run: go vet
+        run: go vet ./...
       - name: Install staticcheck for linting
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: Lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           go-version: '1.21.5'
       - run: scripts/install_dependencies.bash
       - name: Install dependencies
-        run: go get .
+        run: go get ./...
       - name: Run Go tests
         run: go test -coverprofile=/tmp/coverage.out  -bench= -race ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MAIN_PACKAGE_PATH := .
+MAIN_PACKAGE_PATH := ./cmd/asdf
 TARGET_DIR := .
 TARGET := asdf
 FULL_VERSION = $(shell ./scripts/asdf-version )
@@ -31,7 +31,7 @@ lint: fmt
 	revive -set_exit_status ./...
 
 vet: fmt
-	go vet .
+	go vet ./...
 
 run: build
 	${TARGET_DIR}/${TARGET}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,5 +1,5 @@
-// Package cmd contains the asdf CLI command code
-package cmd
+// Package cli contains the asdf CLI command code
+package cli
 
 import (
 	"errors"
@@ -13,21 +13,20 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"asdf/internal/config"
-	"asdf/internal/exec"
-	"asdf/internal/execenv"
-	"asdf/internal/execute"
-	"asdf/internal/help"
-	"asdf/internal/hook"
-	"asdf/internal/info"
-	"asdf/internal/installs"
-	"asdf/internal/pluginindex"
-	"asdf/internal/plugins"
-	"asdf/internal/resolve"
-	"asdf/internal/shims"
-	"asdf/internal/toolversions"
-	"asdf/internal/versions"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/exec"
+	"github.com/asdf-vm/asdf/internal/execenv"
+	"github.com/asdf-vm/asdf/internal/execute"
+	"github.com/asdf-vm/asdf/internal/help"
+	"github.com/asdf-vm/asdf/internal/hook"
+	"github.com/asdf-vm/asdf/internal/info"
+	"github.com/asdf-vm/asdf/internal/installs"
+	"github.com/asdf-vm/asdf/internal/pluginindex"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/resolve"
+	"github.com/asdf-vm/asdf/internal/shims"
+	"github.com/asdf-vm/asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/internal/versions"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/asdf/main.go
+++ b/cmd/asdf/main.go
@@ -1,14 +1,12 @@
 // Main entrypoint for the CLI app
 package main
 
-import (
-	"asdf/cmd"
-)
+import "github.com/asdf-vm/asdf/cli"
 
 // Replaced with the real version during a typical build
 var version = "v-dev"
 
 // Placeholder for the real code
 func main() {
-	cmd.Execute(version)
+	cli.Execute(version)
 }

--- a/cmd/asdf/main_test.go
+++ b/cmd/asdf/main_test.go
@@ -111,7 +111,7 @@ func TestBatsTests(t *testing.T) {
 func runBatsFile(t *testing.T, dir, filename string) {
 	t.Helper()
 
-	cmd := exec.Command("bats", "--verbose-run", fmt.Sprintf("test/%s", filename))
+	cmd := exec.Command("bats", "--verbose-run", fmt.Sprintf("../../test/%s", filename))
 
 	// Capture stdout and stderr
 	var stdout strings.Builder
@@ -127,8 +127,8 @@ func runBatsFile(t *testing.T, dir, filename string) {
 	err := cmd.Run()
 	if err != nil {
 		// If command fails print both stderr and stdout
-		fmt.Println("stdout:", stdout.String())
-		fmt.Println("stderr:", stderr.String())
+		t.Log("stdout:", stdout.String())
+		t.Log("stderr:", stderr.String())
 		t.Fatal("bats command failed to run test file successfully")
 
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module asdf
+module github.com/asdf-vm/asdf
 
 go 1.21.5
 

--- a/internal/execenv/execenv.go
+++ b/internal/execenv/execenv.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"asdf/internal/execute"
-	"asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/execute"
+	"github.com/asdf-vm/asdf/internal/plugins"
 )
 
 const execEnvCallbackName = "exec-env"

--- a/internal/execenv/execenv_test.go
+++ b/internal/execenv/execenv_test.go
@@ -3,10 +3,9 @@ package execenv
 import (
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,8 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/stretchr/testify/assert"

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"strings"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
-	"asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
 )
 
 //go:embed help.txt

--- a/internal/help/help_test.go
+++ b/internal/help/help_test.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"os"
 
-	"asdf/internal/config"
-	"asdf/internal/execute"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/execute"
 )
 
 // Run gets a hook command from config and runs it with the provided arguments.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -4,8 +4,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"asdf/internal/config"
-
+	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"asdf/internal/config"
-	"asdf/internal/execute"
-	"asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/execute"
+	"github.com/asdf-vm/asdf/internal/plugins"
 )
 
 // Print info output to STDOUT

--- a/internal/info/info_test.go
+++ b/internal/info/info_test.go
@@ -6,8 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"asdf/internal/config"
-
+	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"asdf/internal/config"
-	"asdf/internal/data"
-	"asdf/internal/plugins"
-	"asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/data"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
 )
 
 // Installed returns a slice of all installed versions for a given plugin

--- a/internal/installs/installs_test.go
+++ b/internal/installs/installs_test.go
@@ -5,12 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/installtest"
-	"asdf/internal/plugins"
-	"asdf/internal/toolversions"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/installtest"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/installtest/installtest.go
+++ b/internal/installtest/installtest.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
 )
 
 const (

--- a/internal/pluginindex/pluginindex.go
+++ b/internal/pluginindex/pluginindex.go
@@ -9,8 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"asdf/internal/git"
-
+	"github.com/asdf-vm/asdf/internal/git"
 	"gopkg.in/ini.v1"
 )
 

--- a/internal/pluginindex/pluginindex_test.go
+++ b/internal/pluginindex/pluginindex_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"asdf/internal/git"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/git"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -11,12 +11,12 @@ import (
 	"regexp"
 	"strings"
 
-	"asdf/internal/config"
-	"asdf/internal/data"
-	"asdf/internal/execute"
-	"asdf/internal/git"
-	"asdf/internal/hook"
-	"asdf/internal/pluginindex"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/data"
+	"github.com/asdf-vm/asdf/internal/execute"
+	"github.com/asdf-vm/asdf/internal/git"
+	"github.com/asdf-vm/asdf/internal/hook"
+	"github.com/asdf-vm/asdf/internal/pluginindex"
 )
 
 // NewPluginAlreadyExists generates a new PluginAlreadyExists error instance for

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/data"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/data"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -9,9 +9,9 @@ import (
 	"path"
 	"strings"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
-	"asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
 )
 
 // ToolVersions represents a tool along with versions specified for it

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -6,10 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -11,14 +11,13 @@ import (
 	"slices"
 	"strings"
 
-	"asdf/internal/config"
-	"asdf/internal/hook"
-	"asdf/internal/installs"
-	"asdf/internal/paths"
-	"asdf/internal/plugins"
-	"asdf/internal/resolve"
-	"asdf/internal/toolversions"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/hook"
+	"github.com/asdf-vm/asdf/internal/installs"
+	"github.com/asdf-vm/asdf/internal/paths"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/resolve"
+	"github.com/asdf-vm/asdf/internal/toolversions"
 	"golang.org/x/sys/unix"
 )
 

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -8,13 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/installs"
-	"asdf/internal/installtest"
-	"asdf/internal/plugins"
-	"asdf/internal/toolversions"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/installs"
+	"github.com/asdf-vm/asdf/internal/installtest"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )

--- a/internal/toolversions/toolversions.go
+++ b/internal/toolversions/toolversions.go
@@ -50,10 +50,8 @@ func GetAllToolsAndVersions(filepath string) (toolVersions []ToolVersions, err e
 // only the versions found in both.
 func Intersect(versions1 []string, versions2 []string) (versions []string) {
 	for _, version1 := range versions1 {
-		for _, version2 := range versions2 {
-			if version2 == version1 {
-				versions = append(versions, version1)
-			}
+		if slices.Contains(versions2, version1) {
+			versions = append(versions, version1)
 		}
 	}
 	return versions
@@ -63,26 +61,20 @@ func Intersect(versions1 []string, versions2 []string) (versions []string) {
 // versions.
 func Unique(versions []ToolVersions) (uniques []ToolVersions) {
 	for _, version := range versions {
-		var found bool
-
-		for index, unique := range uniques {
-			if unique.Name == version.Name {
-				// Duplicate name, check versions
-				for _, versionNumber := range version.Versions {
-					if !slices.Contains(unique.Versions, versionNumber) {
-						unique.Versions = append(unique.Versions, versionNumber)
-					}
-				}
-
-				uniques[index] = unique
-				found = true
-				break
-			}
+		index := slices.IndexFunc(
+			uniques,
+			func(v ToolVersions) bool { return v.Name == version.Name },
+		)
+		if index < 0 {
+			uniques = append(uniques, version)
+			continue
 		}
 
-		// None with name found, add
-		if !found {
-			uniques = append(uniques, version)
+		unique := &uniques[index]
+		for _, versionNumber := range version.Versions {
+			if !slices.Contains(unique.Versions, versionNumber) {
+				unique.Versions = append(unique.Versions, versionNumber)
+			}
 		}
 	}
 
@@ -165,7 +157,7 @@ func FormatForFS(version Version) string {
 // removing spaces and comments which are marked by '#'
 func readLines(content string) (lines []string) {
 	for _, line := range strings.Split(content, "\n") {
-		line = strings.SplitN(line, "#", 2)[0]
+		line, _, _ = strings.Cut(line, "#")
 		line = strings.TrimSpace(line)
 		if len(line) > 0 {
 			lines = append(lines, line)

--- a/internal/toolversions/toolversions_test.go
+++ b/internal/toolversions/toolversions_test.go
@@ -104,7 +104,7 @@ func TestUnique(t *testing.T) {
 	})
 }
 
-func TestfindToolVersionsInContent(t *testing.T) {
+func TestFindToolVersionsInContent(t *testing.T) {
 	t.Run("returns empty list with found false when empty content", func(t *testing.T) {
 		versions, found := findToolVersionsInContent("", "ruby")
 		assert.False(t, found)
@@ -124,7 +124,7 @@ func TestfindToolVersionsInContent(t *testing.T) {
 	})
 }
 
-func TestgetAllToolsAndVersionsInContent(t *testing.T) {
+func TestGetAllToolsAndVersionsInContent(t *testing.T) {
 	tests := []struct {
 		desc  string
 		input string
@@ -133,7 +133,7 @@ func TestgetAllToolsAndVersionsInContent(t *testing.T) {
 		{
 			desc:  "returns empty list with found true and no error when empty content",
 			input: "",
-			want:  []ToolVersions{},
+			want:  []ToolVersions(nil),
 		},
 		{
 			desc:  "returns list with one tool when single tool in content",
@@ -153,6 +153,10 @@ func TestgetAllToolsAndVersionsInContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			toolsAndVersions := getAllToolsAndVersionsInContent(tt.input)
+			if len(tt.want) == 0 {
+				assert.Empty(t, toolsAndVersions)
+				return
+			}
 			assert.Equal(t, tt.want, toolsAndVersions)
 		})
 	}
@@ -283,4 +287,17 @@ func TestFormatForFS(t *testing.T) {
 	t.Run("returns version prefixed with 'ref-' when version type is ref", func(t *testing.T) {
 		assert.Equal(t, FormatForFS(Version{Type: "ref", Value: "foobar"}), "ref-foobar")
 	})
+}
+
+func BenchmarkUnique(b *testing.B) {
+	versions := []ToolVersions{
+		{Name: "foo", Versions: []string{"1"}},
+		{Name: "bar", Versions: []string{"2"}},
+		{Name: "foo", Versions: []string{"2"}},
+		{Name: "bar", Versions: []string{"2"}},
+	}
+
+	for i := 0; i < b.N; i++ {
+		Unique(versions)
+	}
 }

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -10,13 +10,13 @@ import (
 	"regexp"
 	"strings"
 
-	"asdf/internal/config"
-	"asdf/internal/hook"
-	"asdf/internal/installs"
-	"asdf/internal/plugins"
-	"asdf/internal/resolve"
-	"asdf/internal/shims"
-	"asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/hook"
+	"github.com/asdf-vm/asdf/internal/installs"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/resolve"
+	"github.com/asdf-vm/asdf/internal/shims"
+	"github.com/asdf-vm/asdf/internal/toolversions"
 )
 
 const (

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"asdf/internal/config"
-	"asdf/internal/plugins"
-	"asdf/internal/toolversions"
-	"asdf/repotest"
-
+	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
+	"github.com/asdf-vm/asdf/repotest"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
* Replace direct `fmt.Println()` usage in a test with `t.Log()`
* Rename `cmd` to `cli`
* Move asdf command from module root
* Fix some linter warnings, thus enabling some tests that were being skipped
* Fix `Makefile`
* Rename module to `github.com/asdf-vm/asdf`
* Fix `TestGetAllToolsAndVersionsInContent/returns_empty_list_with_found_true_and_no_error_when_empty_content`
* Rewrite `Unique()` to be a bit more straightforwards
* Get workflow checks passing again

toolversions.Unique is ever so slightly faster, technically.

```
goos: linux
goarch: amd64
pkg: github.com/asdf-vm/asdf/internal/toolversions
cpu: AMD Ryzen 9 3900X 12-Core Processor
          │ /tmp/old.txt │            /tmp/new.txt            │
          │    sec/op    │   sec/op     vs base               │
Unique-24    346.5n ± 1%   342.4n ± 1%  -1.17% (p=0.027 n=10)

          │ /tmp/old.txt │          /tmp/new.txt          │
          │     B/op     │    B/op     vs base            │
Unique-24     160.0 ± 0%   160.0 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

          │ /tmp/old.txt │          /tmp/new.txt          │
          │  allocs/op   │ allocs/op   vs base            │
Unique-24     3.000 ± 0%   3.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```